### PR TITLE
Remplacer le lien vers un repo github qui n'est plus accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wappalyzer-action
 
-Run a [Wappalyzer](https://github.com/AliasIO/wappalyzer) scan and report results as JSON.
+Run a [Wappalyzer](https://www.wappalyzer.com/lookup/) scan and report results as JSON.
 
 ## Usage
 


### PR DESCRIPTION
Il me paraît que le repo originel [est devenu privé](https://github.com/dochne/wappalyzer). Après, j'ai aussi trouvé https://github.com/tunetheweb/wappalyzer alors peut-être c'est ça, mais c'est forké depuis un add-on pour Firefox.